### PR TITLE
Simplify chart titles and improve spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
 <div class="col-span-12 order-5 md:order-none md:col-span-4 lg:col-span-3 xl:col-span-2 px-2" id="sigma-config-container">
   <!-- Sigma Computing plugin controls will appear here -->
 </div>
-<div class="col-span-12 order-6 md:order-none md:col-span-8 lg:col-span-9 xl:col-span-10 px-2" id="charts-container">
+<div class="col-span-12 order-6 md:order-none md:col-span-8 lg:col-span-9 xl:col-span-10 pl-0 pr-2" id="charts-container">
   <div class="flex flex-wrap lg:flex-nowrap gap-2 overflow-scroll">
     <div id="xplot-div" class="my-2 w-11/12 mx-auto flex flex-col justify-start items-center rounded-md box-border border border-gray-300">
       <div id="xplot" style="width: 600px;height:400px;"></div>

--- a/js/main2.ts
+++ b/js/main2.ts
@@ -1692,9 +1692,7 @@ function initialiseECharts(shouldReplaceState: boolean = false) {
   mrChart.setOption({ ...chartBaseOptions }, shouldReplaceState);
   xChart.setOption({
     title: {
-      text:
-        "X Plot" +
-        (state.yLabel.toLowerCase() !== "value" ? `: ${state.yLabel}` : ""),
+      text: state.yLabel,
     },
     xAxis: {
       name: state.xLabel,
@@ -1705,9 +1703,7 @@ function initialiseECharts(shouldReplaceState: boolean = false) {
   });
   mrChart.setOption({
     title: {
-      text:
-        "MR Plot" +
-        (state.yLabel.toLowerCase() !== "value" ? `: ${state.yLabel}` : ""),
+      text: `MR: ${state.yLabel}`,
     },
     xAxis: {
       name: state.xLabel,


### PR DESCRIPTION
## Summary
- Changed X Plot title to just show the column name
- Changed MR Plot title to "MR: [column name]"
- Removed left padding from charts container to maximize space

## Visual changes
- Chart titles are now cleaner and directly show the data column name
- Charts have more horizontal space due to reduced padding
- MR chart clearly labeled with "MR:" prefix

🤖 Generated with [Claude Code](https://claude.ai/code)