### PR TITLE
Fix chart data values to use consistent precision

### DIFF
--- a/js/chart.ts
+++ b/js/chart.ts
@@ -41,6 +41,7 @@ const yAxis = {
     fontSize: 11,
     color: "#000",
     hideOverlap: true,
+    formatter: (value) => Number(value).toFixed(2),
   },
   interval: 500,
   nameLocation: "middle",
@@ -75,9 +76,10 @@ const mapDataValueToChartDataPoint = (dv: DataValue) => ({
     color: dataLabelsStatusColor(dv.status),
     fontWeight: "bold",
     fontSize: 10,
+    formatter: Number(dv.value).toFixed(2),
   },
   tooltip: {
-    formatter: `${dayjs(dv.x).format("ddd, D MMM YYYY")}:<br/> ${dv.value}`,
+    formatter: `${dayjs(dv.x).format("ddd, D MMM YYYY")}:<br/> ${Number(dv.value).toFixed(2)}`,
   },
 });
 

--- a/js/main2.ts
+++ b/js/main2.ts
@@ -1790,7 +1790,7 @@ function renderLimitLines(stats: _Stats) {
           show: false,
         },
         label: {
-          formatter: showLabel && `${statisticY}`,
+          formatter: showLabel && `${Number(statisticY).toFixed(2)}`,
           fontSize: 11,
           color: "#000",
         },
@@ -1972,6 +1972,9 @@ function adjustChartAxis(stats: _Stats) {
       min: xChartYMin,
       max: xChartYMax,
       interval: interval, // Set dynamic interval
+      axisLabel: {
+        formatter: (value) => Number(value).toFixed(2)
+      }
     },
     xAxis: { min: xMin, max: xMax },
   });
@@ -1979,6 +1982,9 @@ function adjustChartAxis(stats: _Stats) {
     yAxis: {
       max: mrChartMax,
       interval: mrInterval, // Set dynamic interval
+      axisLabel: {
+        formatter: (value) => Number(value).toFixed(2)
+      }
     },
     xAxis: { min: xMin, max: xMax },
   });


### PR DESCRIPTION
## Summary
- Fixed inconsistent display precision of data values in charts by enforcing consistent 2 decimal place formatting
- Applied consistent formatting to data point labels, tooltips, limit line labels, and y-axis labels
- Enhances readability and presentation of statistical values throughout the application

## Test plan
- Verify data points display values with exactly 2 decimal places
- Check that axis labels and limits show consistent decimal precision
- Confirm tooltips show values with 2 decimal places

🤖 Generated with [Claude Code](https://claude.ai/code)